### PR TITLE
Fix: Sidebar Collapse Arrow Direction

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -139,3 +139,7 @@
     display: flex;
   }
 }
+
+.collapseIconRotated {
+  transform: rotate(180deg);
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,9 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(styles.collapseMenuItem, {
+                [styles.collapseIconRotated]: isSidebarCollapsed,
+              })}
             />
           </ul>
         </nav>


### PR DESCRIPTION
This PR addresses the issue where the arrow in the "Collapse" button did not indicate the sidebar's collapsed state by always pointing left. Now, the arrow correctly points to the right when the sidebar is collapsed, improving the user interface's intuitiveness.