### PR TITLE
Fix: Reduce Project Card Divider Thickness

### DIFF
--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,7 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 1px solid color.$gray-200;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
This PR adjusts the thickness of the separator line in the project cards to align with the design specifications. The thickness of the divider line was previously set to 3px, which appeared too thick compared to the intended design. It has now been reduced to 1px, providing a more refined and consistent look across the project cards.