### PR TITLE
Fix: Pagination Text Contrast in Issue List

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-700;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
This PR updates the pagination text color in the issue list to `color.$gray-700`, improving contrast and aligning with design specifications.